### PR TITLE
Update to Julia 1.0

### DIFF
--- a/Julia_Notepad++.xml
+++ b/Julia_Notepad++.xml
@@ -1,11 +1,11 @@
 <NotepadPlus>
-    <UserLang name="julia" ext="jl" udlVersion="2.1">
+    <UserLang name="Julia" ext="jl" udlVersion="2.1">
         <Settings>
             <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
-            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="yes" Keywords6="no" Keywords7="no" Keywords8="no" />
         </Settings>
         <KeywordLists>
-            <Keywords name="Comments">00# 01 02((EOL)) 03 04</Keywords>
+            <Keywords name="Comments">00# 01 02 03 04</Keywords>
             <Keywords name="Numbers, prefix1"></Keywords>
             <Keywords name="Numbers, prefix2"></Keywords>
             <Keywords name="Numbers, extras1"></Keywords>
@@ -13,7 +13,7 @@
             <Keywords name="Numbers, suffix1"></Keywords>
             <Keywords name="Numbers, suffix2"></Keywords>
             <Keywords name="Numbers, range"></Keywords>
-            <Keywords name="Operators1">&apos; - ! &quot; $ % &amp; * , . / : ; ? @ \ ^ ` | ~ + &lt; = &gt; &lt;: :: .+ .- .* ./ .\ .^ &amp;&amp; || // [ ] ( ) { }</Keywords>
+            <Keywords name="Operators1">:: ^ + - &#x221A; &lt;&lt; &gt;&gt; &gt;&gt;&gt; // * / % &amp; \ &#x00F7; + - | &#x22BB; : &gt; &lt; &gt;= &lt;= == === != !== &lt;: &amp;&amp; || ? =&gt; = ( ) [ ] { } ,</Keywords>
             <Keywords name="Operators2"></Keywords>
             <Keywords name="Folders in code1, open"></Keywords>
             <Keywords name="Folders in code1, middle"></Keywords>
@@ -24,41 +24,41 @@
             <Keywords name="Folders in comment, open"></Keywords>
             <Keywords name="Folders in comment, middle"></Keywords>
             <Keywords name="Folders in comment, close"></Keywords>
-            <Keywords name="Keywords1">true false C_NULL Inf NaN Inf32 NaN32 nothing</Keywords>
-            <Keywords name="Keywords2">AbstractArray AbstractMatrix AbstractRange AbstractRemoteRef AbstractSparseMatrix AbstractString AbstractVector Any ArgumentError Array Associative BigFloat BigInt BitArray BitMatrix BitVector Bool BunchKaufman Cchar Cdouble Cfloat Char CharString CholeskyDense CholeskyPivotedDense Cint Cintmax_t Clong Clonglong Colon Complex Complex128 Complex64 ComplexPair Cptrdiff_t Cshort Csize_t Cuchar Cuint Cuintmax_t Culong Culonglong Cushort DArray Dict Dims DisconnectException EOFError EachLine EnvDict ErrorException Exception Expr Factorization Filter Float Float32 Float64 Function GSVDDense IO IOBuffer IOStream ImaginaryUnit InsertionSort Int Int128 Int16 Int32 Int64 Int8 BitSet Integer KeyError LDLTTridiagonal LUDense LUTridiagonal LoadError LocalProcess Matrix MergeSort MethodError NTuple Number ObjectIdDict ObjectIdDict OrdinalRange ParseError PipeBuffer ProcessGroup Ptr QRDense QRPivotedDense QuickSort RangeIndex Rational Real Regex RegexMatch RegexMatchIterator RepString RevString Reverse SVDDense Set Signed SparseMatrixCSC SpawnNullStream Stat StridedArray StridedMatrix StridedVecOrMat StridedVector String SubArray SubDArray SubOrDArray SubString SymTridiagonal Symbol SystemError Task TCPSocket TimSort Tridiagonal Tuple Type TypeError UInt UInt128 UInt16 UInt32 UInt64 UInt8 UVError Union UnitRange Unsigned VecOrMat Vector VersionNumber Void WeakKeyDict WeakRef Zip</Keywords>
-            <Keywords name="Keywords3">abstract begin baremodule primitive break catch ccall const continue do else elseif end export finally for function global if struct import importall let local macro module quote return try mutable typealias using while</Keywords>
-            <Keywords name="Keywords4">close enumerate error info open print println read write warn</Keywords>
-            <Keywords name="Keywords5">print println</Keywords>
+            <Keywords name="Keywords1">ARGS C_NULL DEPOT_PATH ENDIAN_BOM ENV Inf Inf32 LOAD_PATH NaN NaN32 PROGRAM_FILE VERSION false im nothing true</Keywords>
+            <Keywords name="Keywords2">AbstractArray AbstractChannel AbstractChar AbstractDict AbstractDisplay AbstractFloat AbstractIrrational AbstractMatrix AbstractRange AbstractSet AbstractString AbstractUnitRange AbstractVecOrMat AbstractVector Any ArgumentError Array AssertionError Base BigFloat BigInt BitArray BitMatrix BitSet BitVector Bool BoundsError Broadcast CapturedException CartesianIndex CartesianIndices Cchar Cdouble Cfloat Channel Char Cint Cintmax_t Clong Clonglong Cmd Colon Complex ComplexF16 ComplexF32 ComplexF64 CompositeException Condition Core Cptrdiff_t Cshort Csize_t Cssize_t Cstring Cuchar Cuint Cuintmax_t Culong Culonglong Cushort Cvoid Cwchar_t Cwstring DataType DenseArray DenseMatrix DenseVecOrMat DenseVector Dict DimensionMismatch Dims DivideError Docs DomainError EOFError Enum ErrorException Exception ExponentialBackOff Expr Float16 Float32 Float64 Function GC GlobalRef HTML IO IOBuffer IOContext IOStream IdDict IndexCartesian IndexLinear IndexStyle InexactError Inf Inf16 Inf32 Inf64 InitError InsertionSort Int Int128 Int16 Int32 Int64 Int8 Integer InteractiveUtils InterruptException InvalidStateException Irrational Iterators KeyError Libc LinRange LineNumberNode LinearIndices LoadError MIME MathConstants Matrix MergeSort Meta Method MethodError Missing MissingException Module NTuple NaN NaN16 NaN32 NaN64 NamedTuple Nothing Number OrdinalRange OutOfMemoryError OverflowError Pair PartialQuickSort PermutedDimsArray Pipe PipeBuffer Ptr QuickSort QuoteNode Rational RawFD ReadOnlyMemoryError Real ReentrantLock Ref Regex RegexMatch RoundDown RoundFromZero RoundNearest RoundNearestTiesAway RoundNearestTiesUp RoundToZero RoundUp RoundingMode SegmentationFault Set Signed Some StackOverflowError StackTraces StepRange StepRangeLen StridedArray StridedMatrix StridedVecOrMat StridedVector String StringIndexError SubArray SubString SubstitutionString Symbol Sys SystemError Task Text TextDisplay Threads Timer Tuple Type TypeError TypeVar UInt UInt128 UInt16 UInt32 UInt64 UInt8 UndefInitializer UndefKeywordError UndefRefError UndefVarError Union UnionAll UnitRange Unsigned Val Vararg VecElement VecOrMat Vector VersionNumber WeakKeyDict WeakRef</Keywords>
+            <Keywords name="Keywords3">abstract baremodule begin break catch const continue do else elseif end export finally for function global if import in let local macro module mutable quote return struct try using where while</Keywords>
+            <Keywords name="Keywords4">abs abs2 abspath accumulate accumulate! acos acosd acosh acot acotd acoth acsc acscd acsch adjoint all all! allunique angle ans any any! append! applicable apropos argmax argmin ascii asec asecd asech asin asind asinh asyncmap asyncmap! atan atand atanh atexit atreplinit axes backtrace basename big bind binomial bitstring broadcast broadcast! bswap bytes2hex bytesavailable cat catch_backtrace cbrt ccall cd ceil cglobal checkbounds checkindex chmod chomp chop chown circcopy! circshift circshift! cis clamp clamp! cld clipboard close cmp coalesce code_llvm code_lowered code_native code_typed code_warntype codepoint codeunit codeunits collect complex conj conj! convert copy copy! copysign copyto! cos cosc cosd cosh cospi cot cotd coth count count_ones count_zeros countlines cp csc cscd csch ctime cumprod cumprod! cumsum cumsum! current_task deepcopy deg2rad delete! deleteat! denominator detach devnull diff digits digits! dirname disable_sigint display displayable displaysize div divrem download dropdims dump eachindex eachline eachmatch edit eltype empty empty! endswith enumerate eof eps error esc escape_string eval evalfile exit exp exp10 exp2 expanduser expm1 exponent extrema factorial falses fd fdio fetch fieldcount fieldname fieldnames fieldoffset fieldtype filemode filesize fill fill! filter filter! finalize finalizer findall findfirst findlast findmax findmax! findmin findmin! findnext findprev first firstindex fld fld1 fldmod fldmod1 flipsign float floatmax floatmin floor flush fma foldl foldr foreach frexp fullname functionloc gcd gcdx gensym get get! get_zero_subnormals getfield gethostname getindex getkey getpid getproperty gperm hash haskey hasmethod hcat hex2bytes hex2bytes! homedir htol hton hvcat hypot identity ifelse ignorestatus imag import include include_dependency include_string indexin insert! instances intersect intersect! inv invmod invoke invperm invpermute! isa isabspath isabstracttype isapprox isascii isassigned isbits isbitstype isblockdev ischardev iscntrl isconcretetype isconst isdefined isdigit isdir isdirpath isdispatchtuple isempty isequal iseven isfifo isfile isfinite isimmutable isinf isinteger isinteractive isless isletter islink islocked islowercase ismarked ismissing ismount isnan isnumeric isodd isone isopen ispath isperm ispow2 isprimitivetype isprint ispunct isqrt isreadable isreadonly isready isreal issetequal issetgid issetuid issocket issorted isspace issticky isstructtype issubnormal issubset istaskdone istaskstarted istextmime isuppercase isvalid iswritable isxdigit iszero iterate join joinpath keys keytype kill kron last lastindex lcm ldexp leading_ones leading_zeros length less lock log log10 log1p log2 lowercase lowercasefirst lpad lstat lstrip ltoh macroexpand map map! mapfoldl mapfoldr mapreduce mapslices mark match max maximum maximum! maxintfloat merge merge! methods methodswith min minimum minimum! minmax missing mkdir mkpath mktemp mktempdir mod mod1 mod2pi modf mtime muladd mv nameof names ncodeunits ndigits ndims nextfloat nextind nextpow nextprod nfields normpath notify ntoh ntuple numerator objectid occursin oftype one ones oneunit open operm pairs parent parentindices parentmodule parse partialsort partialsort! partialsortperm partialsortperm! pathof peakflops permute! permutedims permutedims! pi pipeline pointer pointer_from_objref pop! popdisplay popfirst! position powermod precision precompile prepend! prevfloat prevind prevpow print println printstyled process_exited process_running prod prod! promote promote_rule promote_shape promote_type propertynames push! pushdisplay pushfirst! put! pwd rad2deg rand randn range rationalize read read! readavailable readbytes! readchomp readdir readline readlines readlink readuntil real realpath redirect_stderr redirect_stdin redirect_stdout redisplay reduce reenable_sigint reim reinterpret relpath rem rem2pi repeat replace replace! repr reset reshape resize! rethrow retry reverse reverse! reverseind rm rot180 rotl90 rotr90 round rounding rpad rsplit rstrip run schedule searchsorted searchsortedfirst searchsortedlast sec secd sech seek seekend seekstart selectdim set_zero_subnormals setdiff setdiff! setenv setfield! setindex! setprecision setproperty! setrounding show showable showerror sign signbit signed significand similar sin sinc sincos sind sinh sinpi size sizehint! sizeof skip skipchars skipmissing sleep something sort sort! sortperm sortperm! sortslices splice! split splitdir splitdrive splitext sprint sqrt stacktrace startswith stat stderr stdin stdout step stride strides string strip subtypes success sum sum! summary supertype symdiff symdiff! symlink systemerror take! tan tand tanh task_local_storage tempdir tempname textwidth thisind throw time time_ns timedwait titlecase to_indices touch trailing_ones trailing_zeros transcode transpose trues trunc truncate trylock tryparse tuple type typeassert typeintersect typejoin typemax typemin typeof undef unescape_string union union! unique unique! unlock unmark unsafe_copyto! unsafe_load unsafe_pointer_to_objref unsafe_read unsafe_store! unsafe_string unsafe_trunc unsafe_wrap unsafe_write unsigned uperm uppercase uppercasefirst valtype values varinfo vcat vec versioninfo view wait walkdir which widemul widen withenv write xor yield yieldto zero zeros zip</Keywords>
+            <Keywords name="Keywords5">@</Keywords>
             <Keywords name="Keywords6"></Keywords>
             <Keywords name="Keywords7"></Keywords>
             <Keywords name="Keywords8"></Keywords>
             <Keywords name="Delimiters">00&quot; 01 02&quot; 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
-            <WordsStyle name="DEFAULT" fgColor="93A1A1" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="COMMENTS" fgColor="2AA17A" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="LINE COMMENTS" fgColor="2AA17A" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="NUMBERS" fgColor="B58900" bgColor="FFFFFF" fontName="Lucida Console" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS1" fgColor="268BD2" bgColor="FFFFFF" fontName="Lucida Console" fontStyle="1" nesting="0" />
-            <WordsStyle name="KEYWORDS2" fgColor="CB4B16" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS3" fgColor="6C71C4" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS4" fgColor="D33682" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS5" fgColor="6C71C4" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS6" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS7" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="KEYWORDS8" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="OPERATORS" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
-            <WordsStyle name="FOLDER IN CODE1" fgColor="839496" bgColor="FFFFFF" fontName="Lucida Console" fontStyle="0" nesting="0" />
-            <WordsStyle name="FOLDER IN CODE2" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="FF0000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="FF0000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="0080FF" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS1" fgColor="2AA198" bgColor="FFFFFF" fontName="Lucida Console" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS2" fgColor="800080" bgColor="FFFFFF" fontName="Lucida Console" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS3" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS4" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS5" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS6" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS7" fgColor="839496" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS8" fgColor="839496" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
         </Styles>
     </UserLang>
 </NotepadPlus>


### PR DESCRIPTION
It looks like the currently listed keywords are falling behind. I listed all keywords in Julia Base, including literal values, types, control flows and functions. Also, I removed the keywords in Linear Algebra packages, and changed to a color scheme similar to Python in Npp defaults.